### PR TITLE
fix bug

### DIFF
--- a/src/bit/minisys/minicc/MiniCCompiler.java
+++ b/src/bit/minisys/minicc/MiniCCompiler.java
@@ -131,6 +131,7 @@ public class MiniCCompiler {
 				src += s + "\n";
 			}
 			MiniCCUtil.createAndWriteFile(ppOutFile, src);
+			filename = ppOutFile;
 		}
 		
 		// step 2: scan


### PR DESCRIPTION
When preprocess is skiped, the scanner will get a wrong filename such as "1_scanner_test.c" instead of "1_scanner_test.pp.c".